### PR TITLE
Barebones CLI for pm

### DIFF
--- a/cli/display.go
+++ b/cli/display.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func checkTermSize() {
+	ScreenHeight, ScreenWidth = getTermSize()
+}
+
+func getTermSize() (int, int) {
+	cmd := exec.Command("stty", "size")
+	cmd.Stdin = os.Stdin
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0
+	}
+	dims := strings.Split(strings.Trim(string(out), "\n"), " ")
+	height, _ := strconv.Atoi(dims[0])
+	width, _ := strconv.Atoi(dims[1])
+	return height, width
+}
+
+func clearScreen(keepHist bool) {
+	if keepHist {
+		fmt.Print("\033[2J\033[;H")
+	} else {
+		fmt.Print("\033[0;0H")
+		height, width := ScreenHeight, ScreenWidth
+		blank := ""
+		for width > 0 {
+			blank += " "
+			width--
+		}
+		for height > 0 {
+			fmt.Print(blank)
+			height--
+		}
+		fmt.Print("\033[0;0H")
+	}
+}

--- a/cli/input.go
+++ b/cli/input.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func inputLoop() {
+	for {
+		switch readKey() {
+		case "k":
+			paused = true
+
+			host := ""
+			id := ""
+			message := ""
+			fmt.Println()
+			host = readString("Host: ")
+			id = readString("ID: ")
+			message = readString("Message: ")
+			fmt.Printf("Killing ID %s on %s with message %s.\n", id, host, message)
+			if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+				host = "http://" + host
+			}
+
+			client, exists := clients[host]
+			if exists {
+				client.Kill(id, message)
+			}
+
+			paused = false
+		case "p":
+			paused = !paused
+		case "q":
+			os.Exit(0)
+		}
+	}
+}
+
+func readKey() string {
+	var b []byte = make([]byte, 1)
+	os.Stdin.Read(b)
+	return string(b)
+}
+
+func readString(prompt string) string {
+	// enable input buffering (cooked mode) temporarily
+	exec.Command("stty", "-f", "/dev/tty", "cooked").Run()
+	defer exec.Command("stty", "-f", "/dev/tty", "cbreak").Run()
+
+	read := ""
+	fmt.Print(prompt + " ")
+
+	fmt.Scanf("%s", &read)
+	return read
+}

--- a/cli/pm-cli.go
+++ b/cli/pm-cli.go
@@ -1,29 +1,29 @@
-// Program cli is a commandline client for the pm processlist manager.
 package main
 
-// Copyright (c) 2014 VividCortex, Inc. All rights reserved.
-// Please see the LICENSE file for applicable license terms.
-
 import (
-	"encoding/json"
+	"github.com/VividCortex/multitick"
+	"github.com/VividCortex/pm"
+	"github.com/VividCortex/pm/client"
+
 	"flag"
 	"fmt"
-	"log"
-	"net/http"
+	"os/exec"
 	"sort"
 	"strings"
 	"time"
-
-	"github.com/VividCortex/multitick"
 )
 
 var (
-	RefreshInterval = 3 * time.Second
-	ScreenHeight    = 40
-	ScreenWidth     = 160
 	Endpoints       = "" // e.g. "api1:9085,api2:9085,api1:9086,api2:9086"
-	Display         = make(chan []Line)
-	Trickle         = make(chan Line)
+	KeepHist        = true
+	RefreshInterval = time.Second
+	clients         = map[string]*client.Client{}
+
+	ScreenHeight = 40
+	ScreenWidth  = 160
+
+	Display = make(chan []Line)
+	Trickle = make(chan Line)
 
 	// These might need to be protected by mutexes
 	Columns   = []string{"Host", "Id", "Time", "Status"}
@@ -33,58 +33,51 @@ var (
 		"Time":   len("300.123s"),
 		"Status": len("this one is a long enough status!"),
 	}
+
+	paused = false
 )
 
-// Message is the response from the pm server, retrieved from /procs/.
-type Message struct {
-	Procs      []Proc
-	ServerTime time.Time
-}
-
-// Proc is a single process within the Message.
-type Proc struct {
-	Id                   string
-	Status               string
-	Attrs                []Attr
-	ProcTime, StatusTime time.Time
-}
-
-// Attr is a process's attribute.
-type Attr struct {
-	Name, Value string
-}
-
-// Line is one line of output on the terminal.
 type Line struct {
 	Host, Id, Status   string
 	ProcAge, StatusAge time.Duration
 	Cols               map[string]string
 }
 
+func init() {
+	// disable input buffering
+	exec.Command("stty", "-f", "/dev/tty", "cbreak").Run()
+	checkTermSize()
+}
+
 func main() {
 	flag.StringVar(&Endpoints, "endpoints", Endpoints, "Comma-separated host:port list of APIs to poll")
-	flag.DurationVar(&RefreshInterval, "interval", RefreshInterval, "Delay between refreshes")
-	flag.IntVar(&ScreenHeight, "screen-height", ScreenHeight, "Height of terminal, in lines of text")
-	flag.IntVar(&ScreenWidth, "screen-width", ScreenWidth, "Width of terminal, in columns of text")
+	flag.BoolVar(&KeepHist, "keep-hist", KeepHist, "Keep output history on refreshes")
+	flag.DurationVar(&RefreshInterval, "refresh", RefreshInterval, "Time interval between refreshes")
 	flag.Parse()
 
-	// Set global HTTP read timeout (just for the headers of the request)
-	http.DefaultTransport.(*http.Transport).ResponseHeaderTimeout = time.Second
+	ticker := multitick.NewTicker(RefreshInterval, RefreshInterval)
 
-	ticker := multitick.NewTicker(RefreshInterval, time.Second)
 	endpoints := strings.Split(Endpoints, ",")
-
 	for _, e := range endpoints {
 		if !strings.HasPrefix(e, "http://") && !strings.HasPrefix(e, "https://") {
 			e = "http://" + e
 		}
+		clients[e] = client.NewClient(e)
+
 		go poll(e, ticker.Subscribe())
 	}
 
 	go top(ticker.Subscribe())
+	go inputLoop()
 
+	clearScreen(true)
 	for lines := range Display {
-		fmt.Print("\033[2J\033[;H") // clear the screen
+		if paused {
+			continue
+		}
+
+		checkTermSize()
+		clearScreen(KeepHist)
 
 		// Compute and print column headers
 		lineFormat := ""
@@ -109,7 +102,7 @@ func main() {
 				output = output[:ScreenWidth]
 			}
 			fmt.Println(output)
-			if printed == ScreenHeight {
+			if printed == ScreenHeight-1 {
 				break
 			}
 		}
@@ -119,43 +112,34 @@ func main() {
 // poll one of the endpoints for its /procs/ data.
 func poll(hostPort string, ticker <-chan time.Time) {
 	for _ = range ticker {
-		res, err := http.Get(hostPort + "/procs/")
-		if err != nil {
-			log.Println(hostPort, err)
-			continue
+		msg, err := clients[hostPort].Processes()
+		if err == nil {
+			msgToLines(hostPort, msg)
 		}
-		if res.StatusCode == 200 {
-			msg := Message{}
-			dec := json.NewDecoder(res.Body)
-			err := dec.Decode(&msg)
-			if err != nil {
-				log.Println(hostPort, err)
-			} else {
-				for _, p := range msg.Procs {
-					l := Line{
-						Host:      strings.Replace(hostPort, "http://", "", -1),
-						Id:        p.Id,
-						Status:    p.Status,
-						ProcAge:   msg.ServerTime.Sub(p.ProcTime),
-						StatusAge: msg.ServerTime.Sub(p.StatusTime),
-						Cols:      map[string]string{},
-					}
-					for _, a := range p.Attrs {
-						colLen, ok := LengthFor[a.Name]
-						if !ok {
-							Columns = append(Columns, a.Name)
-						}
-						if len(a.Name) > colLen {
-							LengthFor[a.Name] = len(a.Name)
-						}
-						l.Cols[a.Name] = a.Value
-					}
-					Trickle <- l
-				}
+	}
+}
+
+func msgToLines(hostPort string, msg *pm.ProcResponse) {
+	for _, p := range msg.Procs {
+		l := Line{
+			Host:      strings.Replace(hostPort, "http://", "", -1),
+			Id:        p.Id,
+			Status:    p.Status,
+			ProcAge:   msg.ServerTime.Sub(p.ProcTime),
+			StatusAge: msg.ServerTime.Sub(p.StatusTime),
+			Cols:      map[string]string{},
+		}
+		for name, value := range p.Attrs {
+			colLen, ok := LengthFor[name]
+			if !ok {
+				Columns = append(Columns, name)
 			}
-		} else {
-			log.Println(hostPort, res.Status)
+			if len(name) > colLen {
+				LengthFor[name] = len(name)
+			}
+			l.Cols[name] = value.(string)
 		}
+		Trickle <- l
 	}
 }
 

--- a/http.go
+++ b/http.go
@@ -22,12 +22,9 @@ func (pl *Proclist) getProcs() []ProcDetail {
 
 	for id, p := range pl.procs {
 		p.mu.RLock()
-		attrs := make([]AttrDetail, 0, len(p.attrs))
+		attrs := make(map[string]interface{})
 		for name, value := range p.attrs {
-			attrs = append(attrs, AttrDetail{
-				Name:  name,
-				Value: value,
-			})
+			attrs[name] = value
 		}
 		firstHEntry := p.history.Front().Value.(*historyEntry)
 		lastHEntry := p.history.Back().Value.(*historyEntry)

--- a/pm_test.go
+++ b/pm_test.go
@@ -24,17 +24,6 @@ func attrMapEquals(m1, m2 map[string]interface{}) bool {
 	return true
 }
 
-func attrMap(t *testing.T, p *ProcDetail) map[string]interface{} {
-	attrs := make(map[string]interface{})
-	for _, attr := range p.Attrs {
-		if _, present := attrs[attr.Name]; present {
-			t.Error("attribute doubly defined:", attr.Name)
-		}
-		attrs[attr.Name] = attr.Value
-	}
-	return attrs
-}
-
 func procMapEquals(t *testing.T, m1, m2 map[string]ProcDetail) bool {
 	if len(m1) != len(m2) {
 		return false
@@ -44,7 +33,7 @@ func procMapEquals(t *testing.T, m1, m2 map[string]ProcDetail) bool {
 			return false
 		} else if v1.Id != v2.Id || v1.Status != v2.Status || v1.Cancelling != v2.Cancelling {
 			return false
-		} else if !attrMapEquals(attrMap(t, &v1), attrMap(t, &v2)) {
+		} else if !attrMapEquals(v1.Attrs, v2.Attrs) {
 			return false
 		}
 	}
@@ -138,10 +127,10 @@ func TestProclist(t *testing.T) {
 		t.Error("bad status for req2; expecting 'init', got ", p2.Status)
 	}
 
-	if !attrMapEquals(attrMap(t, &p1), attrs1) {
+	if !attrMapEquals(p1.Attrs, attrs1) {
 		t.Error("bad attribute set for req1")
 	}
-	if !attrMapEquals(attrMap(t, &p2), attrs2) {
+	if !attrMapEquals(p2.Attrs, attrs2) {
 		t.Error("bad attribute set for req2")
 	}
 

--- a/types.go
+++ b/types.go
@@ -7,21 +7,15 @@ import (
 	"time"
 )
 
-// AttrDetail encodes a single, user-defined name/value pair.
-type AttrDetail struct {
-	Name  string      `json:"name"`
-	Value interface{} `json:"value"`
-}
-
 // Type ProcDetail encodes a full process list from the server, including an
 // attributes array with application-defined names/values.
 type ProcDetail struct {
-	Id         string       `json:"id"`
-	Attrs      []AttrDetail `json:"attrs,omitempty"`
-	ProcTime   time.Time    `json:"procTime"`
-	StatusTime time.Time    `json:"statusTime"`
-	Status     string       `json:"status"`
-	Cancelling bool         `json:"cancelling,omitempty"`
+	Id         string                 `json:"id"`
+	Attrs      map[string]interface{} `json:"attrs,omitempty"`
+	ProcTime   time.Time              `json:"procTime"`
+	StatusTime time.Time              `json:"statusTime"`
+	Status     string                 `json:"status"`
+	Cancelling bool                   `json:"cancelling,omitempty"`
 }
 
 // ProcResponse is the response for a GET to /proc.


### PR DESCRIPTION
I wrote this code without thinking very clearly. I should have seen that there is already a Go client library for the HTTP API and that types are already defined. But I'm pushing it because it's better than nothing, and it illustrates the base behavior I want.

Things that need to be fixed before this is worth considering IMO:
- We need to use commandline flags to make some of the variables settable.
- We should use the included types and the Go client library.

Things I would like to improve after that:
- Auto-detect the screen size.
- Make the client library support a timeout if requests hang.
- Support basic keystroke commands; these are documented in issues already.
